### PR TITLE
don't try to call has_children() on undefined

### DIFF
--- a/frontend/src/task_list/TaskList.svelte
+++ b/frontend/src/task_list/TaskList.svelte
@@ -527,7 +527,7 @@
 					return;
 
 				task.update(t => t._edit_status = ['exposition']);
-			} else if (task.has_children())
+			} else if (task && task.has_children())
 				create_child_task(task);
 			else
 				create_sibling_task('after');


### PR DESCRIPTION
ran into this when giving the project a whirl with a completely clean json dir - if no tasks exist and you hit `Enter`, TypeError happens because there is no `task`